### PR TITLE
Don't cleanup cache key file

### DIFF
--- a/cache-types/ruby/ruby.sh
+++ b/cache-types/ruby/ruby.sh
@@ -22,6 +22,3 @@ else
     AWS_SECRET_ACCESS_KEY="$PLUGIN_AWS_SECRET_ACCESS_KEY" \
     /usr/local/rust-cache
 fi
-
-
-rm .cache_key

--- a/cache-types/rust/rust.sh
+++ b/cache-types/rust/rust.sh
@@ -22,6 +22,3 @@ else
     AWS_SECRET_ACCESS_KEY="$PLUGIN_AWS_SECRET_ACCESS_KEY" \
     /usr/local/rust-cache
 fi
-
-
-rm .cache_key

--- a/cache-types/yarn/yarn.sh
+++ b/cache-types/yarn/yarn.sh
@@ -27,7 +27,4 @@ pushd "$BASE_DIR"
       AWS_SECRET_ACCESS_KEY="$PLUGIN_AWS_SECRET_ACCESS_KEY" \
       /usr/local/rust-cache
   fi
-
-
-  rm .cache_key
 popd


### PR DESCRIPTION
Attempting to cleanup the cache key file failed a build on me. Instead
of figuring out why I am putting this band-aid on, and just not cleaning
up the cache key.

This doesn't really need to be cleaned up cause these all run in
ephemeral containers